### PR TITLE
#25 로그아웃 기능 구현

### DIFF
--- a/http/member-test.http
+++ b/http/member-test.http
@@ -20,8 +20,8 @@ POST http://localhost:8001/members/login
 Content-Type: application/json
 
 {
-  "memberId" : "a",
-  "memberPassword" : "a"
+  "memberId" : "user02",
+  "memberPassword" : "pass02"
 }
 
 ### 인증 되어야 하는 기능을 대상으로 테스트
@@ -42,5 +42,9 @@ GET http://localhost:8001/admin
 Access-Token: Bearer eyJkYXRlIjoxNzE2Nzc5NTMwNzM2LCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJtZW1iZXJJZCI6InVzZXIwMiIsIm1lbWJlclJvbGUiOiJST0xFX01FTUJFUiIsImV4cCI6MTcxNjc4MzEzMH0.CO1_5Cy1-ryPLBt1fCBIkp51EwWd4K_sVnl6B6_Fol2IlyjpuYxXExty421_2QwlE6h-bvN-Uh5N9rwhjvRF1A
 
 ### 프로필 조회
-GET http://localhost:8001/members/a
-Access-Token: Bearer eyJkYXRlIjoxNzE2OTY4MDc0ODMzLCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJtZW1iZXJSb2xlIjoiUk9MRV9NRU1CRVIiLCJtZW1iZXJJZCI6ImEiLCJleHAiOjE3MTY5NzE2NzR9.chSvXyMWExuoR3YIZxmC-PN06lymYHpXbMCfebenB98s2ZniS0of58tfx0lfscbroG1LHqR0VFhFkI8bna06SQ
+GET http://localhost:8001/members/user02
+Access-Token: Bearer eyJkYXRlIjoxNzE2OTcxNTY3MzU4LCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJtZW1iZXJSb2xlIjoiUk9MRV9NRU1CRVIiLCJtZW1iZXJJZCI6InVzZXIwMiIsImV4cCI6MTcxNjk3NTE2N30.pOI8vOlRjdZLiSQUQZmxbUB2DXe4tob6tWIvbC1cjrhHXtRGdrRlj2dvMBlN3d7FBWeSmi4ylS9ElXaZEwHlMA
+
+### 로그아웃
+POST http://localhost:8001/members/logout
+Access-Token: Bearer eyJkYXRlIjoxNzE2OTcxNTY3MzU4LCJ0eXBlIjoiand0IiwiYWxnIjoiSFM1MTIifQ.eyJtZW1iZXJSb2xlIjoiUk9MRV9NRU1CRVIiLCJtZW1iZXJJZCI6InVzZXIwMiIsImV4cCI6MTcxNjk3NTE2N30.pOI8vOlRjdZLiSQUQZmxbUB2DXe4tob6tWIvbC1cjrhHXtRGdrRlj2dvMBlN3d7FBWeSmi4ylS9ElXaZEwHlMA

--- a/src/main/java/yep/greenFire/greenfirebackend/user/member/presentation/MemberController.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/user/member/presentation/MemberController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import yep.greenFire.greenfirebackend.user.member.dto.request.MemberSignupRequest;
 import yep.greenFire.greenfirebackend.user.member.dto.response.ProfileResponse;
@@ -40,6 +42,15 @@ public class MemberController {
         ProfileResponse profileResponse = memberService.getProfile(memberId);
 
         return ResponseEntity.ok(profileResponse);
+    }
+
+    // 로그아웃 시 DB 토큰 무효화
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal UserDetails userDetails) {
+
+        memberService.updateRefreshToken(userDetails.getUsername(), null);
+
+        return ResponseEntity.ok().build();
     }
 
 }


### PR DESCRIPTION
<!-- 제목 형식: [#이슈번호] 구현 내용 (한글로)
  ex : #1 싱품 조회 기능 구현 -->

## 📫 PR 유형
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능
  ex : [x] 기능 추가 -->

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🔖 요약
> 로그아웃 기능 구현

## 💻 작업 내용
- 로그아웃 시 DB의 refreshToken 무효화

## 📚 참고 사항
- jwt 기반 토큰 방식에서의 이슈
- https://upcurvewave.tistory.com/611
: stateless 특성에 따라 서버가 클라이언트의 인증 상태를
  직접 관리하지 않기 때문에 이미 발급된 토큰들에 대한 관리가 안되는 상황.
  추후 프론트엔드에서 토큰 삭제 / 토큰 블랙리스트 관리 / 리프레시 토큰의 기간 만료처리 등의 방법으로 문제를 해결할 예정

## 📌 관련 이슈
- Close #25 
