### PR TITLE
#121 회원가입 이메일 본인인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/yep/greenFire/greenfirebackend/auth/config/SchedulerConfig.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/auth/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package yep.greenFire.greenfirebackend.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/auth/config/SecurityConfig.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/auth/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                     /* 클라이언트가 외부 도메인을 요청하는 경우 웹 브라우저에서 자체적으로 사전 요청(preflight)이 일어난다.
                      * 이 때 OPTIONS 메소드로 서버에 사전 요청을 보내 확인한다. */
                     auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
-                    auth.requestMatchers(HttpMethod.POST, "/members/signup", "/members/login").permitAll();
+                    auth.requestMatchers(HttpMethod.POST, "/members/signup", "/members/login", "/api/auth/verify-email").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/admin/notices/**").permitAll();
                     auth.requestMatchers("/admin/**").hasRole(MemberRole.ADMIN.toString());
                     auth.requestMatchers("/seller/mystore/**").hasRole(MemberRole.SELLER.toString());

--- a/src/main/java/yep/greenFire/greenfirebackend/auth/dto/Test.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/auth/dto/Test.java
@@ -1,4 +1,0 @@
-package yep.greenFire.greenfirebackend.auth.dto;
-
-public class Test {
-}

--- a/src/main/java/yep/greenFire/greenfirebackend/auth/presentaition/AuthController.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/auth/presentaition/AuthController.java
@@ -1,0 +1,34 @@
+package yep.greenFire.greenfirebackend.auth.presentaition;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yep.greenFire.greenfirebackend.email.dto.request.VerificationRequest;
+import yep.greenFire.greenfirebackend.email.service.EmailVerificationService;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/verify-email")
+    public ResponseEntity<?> verifyEmail(@RequestBody VerificationRequest verificationRequest) {
+        String verificationResult = emailVerificationService.verifyEmail(verificationRequest.getMemberCode(), verificationRequest.getVerificationCode());
+
+        switch (verificationResult) {
+            case "verified":
+                return ResponseEntity.ok("회원가입이 완료되었습니다.");
+            case "expired":
+                return ResponseEntity.badRequest().body("인증코드가 만료되었습니다.");
+            case "already_verified":
+                return ResponseEntity.badRequest().body("이미 인증이 완료된 코드입니다.");
+            default:
+                return ResponseEntity.badRequest().body("인증코드가 다르거나 만료되었습니다.");
+        }
+    }
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/domain/entity/EmailVerification.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/domain/entity/EmailVerification.java
@@ -1,0 +1,30 @@
+package yep.greenFire.greenfirebackend.email.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tbl_email_verification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberCode;
+
+    private String verificationCode;
+
+    private LocalDateTime expirationTime;
+
+    private boolean isVerified = false;
+
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/domain/entity/EmailVerification.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/domain/entity/EmailVerification.java
@@ -27,4 +27,18 @@ public class EmailVerification {
 
     private boolean isVerified = false;
 
+    private EmailVerification(Long memberCode, String verificationCode, LocalDateTime expirationTime) {
+        this.memberCode = memberCode;
+        this.verificationCode = verificationCode;
+        this.expirationTime = expirationTime;
+        this.isVerified = false;
+    }
+
+    public static EmailVerification of(Long memberCode, String verificationCode, LocalDateTime expirationTime) {
+        return new EmailVerification(memberCode, verificationCode, expirationTime);
+    }
+
+    public void verify() {
+        this.isVerified = true;
+    }
 }

--- a/src/main/java/yep/greenFire/greenfirebackend/email/domain/repository/EmailVerificationRepository.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/domain/repository/EmailVerificationRepository.java
@@ -1,0 +1,14 @@
+package yep.greenFire.greenfirebackend.email.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yep.greenFire.greenfirebackend.email.domain.entity.EmailVerification;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findByMemberCodeAndVerificationCode(Long memberCode, String verificationCode);
+    void deleteByExpirationTimeBefore(LocalDateTime now);
+
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/dto/request/VerificationRequest.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/dto/request/VerificationRequest.java
@@ -1,0 +1,13 @@
+package yep.greenFire.greenfirebackend.email.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class VerificationRequest {
+
+    private Long memberCode;
+    private String verificationCode;
+
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailService.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailService.java
@@ -1,0 +1,22 @@
+package yep.greenFire.greenfirebackend.email.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailVerificationCleanupService.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailVerificationCleanupService.java
@@ -1,0 +1,22 @@
+package yep.greenFire.greenfirebackend.email.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import yep.greenFire.greenfirebackend.email.domain.repository.EmailVerificationRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationCleanupService {
+
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    public void cleanUpExpiredVerificationCodes() {
+        LocalDateTime now = LocalDateTime.now();
+        emailVerificationRepository.deleteByExpirationTimeBefore(now);
+    }
+
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailVerificationService.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/email/service/EmailVerificationService.java
@@ -1,0 +1,66 @@
+package yep.greenFire.greenfirebackend.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import yep.greenFire.greenfirebackend.email.domain.entity.EmailVerification;
+import yep.greenFire.greenfirebackend.email.domain.repository.EmailVerificationRepository;
+import yep.greenFire.greenfirebackend.member.domain.entity.Member;
+import yep.greenFire.greenfirebackend.member.domain.repository.MemberRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final MemberRepository memberRepository;
+    private final EmailService emailService;
+
+    public void generateAndSendVerificationCode(Long memberCode, String email) {
+        String verificationCode = generateVerificationCode();
+        LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(10); // 10분 후 만료
+
+        EmailVerification emailVerification = EmailVerification.of(memberCode, verificationCode, expirationTime);
+        emailVerificationRepository.save(emailVerification);
+        emailService.sendEmail(email, "초록불 회원가입 인증번호", "인증번호: " + verificationCode);
+    }
+
+    public String verifyEmail(Long memberCode, String verificationCode) {
+        Optional<EmailVerification> emailVerificationOpt = emailVerificationRepository.findByMemberCodeAndVerificationCode(memberCode, verificationCode);
+
+        if (emailVerificationOpt.isPresent()) {
+            EmailVerification emailVerification = emailVerificationOpt.get();
+            if (emailVerification.isVerified()) {
+                return "already_verified";
+            }
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime expirationTime = emailVerification.getExpirationTime();
+            // 완료된 인증번호 테스트
+            log.info("Current time: {}", now);
+            log.info("Expiration time: {}", expirationTime);
+            if (expirationTime.isBefore(now)) {
+                return "expired";
+            }
+            emailVerification.verify();
+            emailVerificationRepository.save(emailVerification);
+
+            Optional<Member> memberOpt = memberRepository.findById(memberCode);
+            if (memberOpt.isPresent()) {
+                Member member = memberOpt.get();
+                member.activate();
+                memberRepository.save(member);
+                return "verified";
+            }
+        }
+        return "invalid";
+    }
+
+    private String generateVerificationCode() {
+        return UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+    }
+}

--- a/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "tbl_member")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Member {

--- a/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
@@ -44,24 +44,30 @@ public class Member {
     private LocalDateTime suspendedEndDate;
 
 
-    private Member(String memberId, String memberPassword, String memberName, String memberNickname, String memberEmail, String memberPhone) {
+    private Member(String memberId, String memberPassword, String memberName, String memberNickname, String memberEmail, String memberPhone, MemberStatus memberStatus) {
         this.memberId = memberId;
         this.memberPassword = memberPassword;
         this.memberName = memberName;
         this.memberNickname = memberNickname == null || memberNickname.trim().isEmpty() ? memberId : memberNickname;
         this.memberEmail = memberEmail;
         this.memberPhone = memberPhone;
+        this.memberStatus = memberStatus;
     }
 
-    public static Member of(String memberId, String memberPassword, String memberName, String memberNickname, String memberEmail, String memberPhone) {
+    public static Member of(String memberId, String memberPassword, String memberName, String memberNickname, String memberEmail, String memberPhone, MemberStatus memberStatus) {
         return new Member(
                 memberId,
                 memberPassword,
                 memberName,
                 memberNickname,
                 memberEmail,
-                memberPhone
+                memberPhone,
+                memberStatus
         );
+    }
+
+    public void activate() {
+        this.memberStatus = MemberStatus.ACTIVE;
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/domain/entity/Member.java
@@ -16,7 +16,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "tbl_member")
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class Member {

--- a/src/main/java/yep/greenFire/greenfirebackend/member/domain/type/MemberStatus.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/domain/type/MemberStatus.java
@@ -1,5 +1,5 @@
 package yep.greenFire.greenfirebackend.member.domain.type;
 
 public enum MemberStatus {
-    ACTIVE, STOP,PERMANENTLY_SUSPENDED,QUIT
+    INACTIVE, ACTIVE, STOP, PERMANENTLY_SUSPENDED, QUIT
 }

--- a/src/main/java/yep/greenFire/greenfirebackend/member/dto/request/MemberSignupRequest.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/dto/request/MemberSignupRequest.java
@@ -3,6 +3,7 @@ package yep.greenFire.greenfirebackend.member.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import yep.greenFire.greenfirebackend.member.domain.type.MemberStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -19,5 +20,6 @@ public class MemberSignupRequest {
     private final String memberEmail;
     @NotBlank
     private final String memberPhone;
+    private final MemberStatus memberStatus = MemberStatus.INACTIVE;
 
 }

--- a/src/main/java/yep/greenFire/greenfirebackend/member/presentation/MemberController.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/presentation/MemberController.java
@@ -8,12 +8,11 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import yep.greenFire.greenfirebackend.auth.type.CustomUser;
+import yep.greenFire.greenfirebackend.email.service.EmailVerificationService;
 import yep.greenFire.greenfirebackend.member.dto.request.MemberSignupRequest;
 import yep.greenFire.greenfirebackend.member.dto.request.ProfileUpdateRequest;
 import yep.greenFire.greenfirebackend.member.service.MemberService;
 import yep.greenFire.greenfirebackend.member.dto.response.ProfileResponse;
-
-import java.net.URI;
 
 @RestController
 @RequestMapping("/members")
@@ -21,12 +20,16 @@ import java.net.URI;
 public class MemberController {
 
     private final MemberService memberService;
+    private final EmailVerificationService emailVerificationService;
 
     // 회원 가입
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@RequestBody @Valid MemberSignupRequest memberRequest) {
 
-        memberService.signup(memberRequest);
+        Long memberCode = memberService.signup(memberRequest);
+
+        // 이메일 인증 코드 발송
+        emailVerificationService.generateAndSendVerificationCode(memberCode, memberRequest.getMemberEmail());
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/yep/greenFire/greenfirebackend/member/service/MemberService.java
+++ b/src/main/java/yep/greenFire/greenfirebackend/member/service/MemberService.java
@@ -25,7 +25,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public void signup(MemberSignupRequest memberRequest) {
+    public Long signup(MemberSignupRequest memberRequest) {
 
         final Member newMember = Member.of(
                 memberRequest.getMemberId(),
@@ -33,10 +33,13 @@ public class MemberService {
                 memberRequest.getMemberName(),
                 memberRequest.getMemberNickname(),
                 memberRequest.getMemberEmail(),
-                memberRequest.getMemberPhone()
+                memberRequest.getMemberPhone(),
+                memberRequest.getMemberStatus()
         );
 
         memberRepository.save(newMember);
+
+        return newMember.getMemberCode();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
<!-- 제목 형식: [#이슈번호] 구현 내용 (한글로)
  ex : #1 상품 조회 기능 구현 -->

## 📫 PR 유형
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능
  ex : [x] 기능 추가 -->

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🔖 요약
> 이메일 본인인증 기능

## 💻 작업 내용
- 이메일 인증 코드 생성
  : 6자리 영문 대문자 / 숫자 랜덤 조합
  
- SMTP 이메일 발송
  : 구글 이메일로 발송 / **yml 업데이트**
  
- 사용자 이메일 코드 검증
  : 검증 후 badRequest 설정
    1. 만료된 인증코드 (인증 만료 시간 10분)
    2. 완료된 인증코드
    3. default
    
- 성공 시 핸들러
  : 성공 시 memberStatus : INACTIVE -> ACTIVE
  : memberStatus 제약조건 추가 (수정 쿼리문 디스코드, 노션 업로드 완료)
  
- 인증용 DB 저장공간 관리 (스프링 스케줄러)
  : 스프링 스케줄러를 사용하여 주기적으로 만료된 인증 코드를 삭제 (매일 자정)

## 📚 참고 사항
- 레디스 배포 후 비용 이슈로 레디스의 TTL(Time To Live)과 유사한 기능을 구현
- application.yml 업데이트

## 📌 관련 이슈
- Close #121 
